### PR TITLE
Experiment/ex ante

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -44,6 +44,7 @@ def make_app():
     tornado.options.parse_command_line()
     return tornado.web.Application([
         (r"/", MainHandler),
+        (r"/backend", MainHandler)
     ])
 
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -50,8 +50,8 @@ def make_app():
 
 def optimize_allocations(stock_params):
     """Call methods to get stock data and find optimal allocations."""
-    prices = get_data(stock_params)
-    allocs = optimize_portfolio(prices)
+    prices, prices_SPY = get_data(stock_params)
+    allocs = optimize_portfolio(prices, prices_SPY)
     return allocs
 
 

--- a/backend/optimizer/optimize.py
+++ b/backend/optimizer/optimize.py
@@ -5,39 +5,36 @@ import pandas as pd
 import scipy.optimize as spo
 
 
-def get_portfolio_value(prices, allocs, start_val=1):
+def get_portfolio_value(prices, allocs, start_val=1.):
     """Compute daily portfolio value.
 
-    Parameters
-    ----------
-        prices: daily prices for each stock in portfolio
-        allocs: initial allocations, as fractions that sum to 1
-        start_val: total starting value invested in portfolio (default: 1)
+    Args:
+        prices (dataframe): daily prices for each stock in portfolio
+        allocs (list): initial allocations, as fractions that sum to 1
+        start_val: total starting value invested in portfolio (default: 1.)
 
-    Returns
-    -------
-        port_val: daily portfolio value
+    Returns:
+        portfolio_value (dataframe): daily portfolio value
     """
     normed = prices/prices.ix[0]
-    alloced = normed * allocs
-    pos_vals = alloced * start_val
-    port_val = pos_vals.sum(axis=1)
+    position_values = normed * allocs * start_val
+    portfolio_value = position_values.sum(axis=1)
 
-    return port_val
+    return portfolio_value
 
 
-def get_portfolio_stats(port_val, daily_rf=0.0005752, samples_per_year=252):
+def get_portfolio_stats(port_val, SPY_val, daily_rf=5.752e-4, yearly_samples=252):
     """Calculate statistics on given portfolio values.
 
-    Parameters
-    ----------
-        port_val: daily portfolio value
-        daily_rf: daily risk-free rate of return = ((1+yearly_percent)^(1/360) - 1)/100%
-        samples_per_year: frequency of sampling (default: 252 trading days)
+    Args:
+        port_val (dataframe): daily portfolio value
+        daily_rf: daily risk-free rate of return (default: 5.752e-4)
+            rf = ((1+yearly_percent)^(1/360) - 1)/100%
+        yearly_samples: frequency of sampling (default: 252)
+            There are 252 trading days in a year.
 
-    Returns
-    -------
-        cum_ret: cumulative return
+    Returns:
+        cum_ret (): cumulative return
         avg_daily_ret: average of daily returns
         std_daily_ret: standard deviation of daily returns
         sharpe_ratio: annualized Sharpe ratio
@@ -49,24 +46,32 @@ def get_portfolio_stats(port_val, daily_rf=0.0005752, samples_per_year=252):
     daily_ret[1:] = (port_val[1:] / port_val[:-1].values)-1
     daily_ret = daily_ret.ix[1:]
 
+    # Calculate SPY daily returns
+    daily_ret_SPY = SPY_val.copy()
+    daily_ret_SPY[1:] = (SPY_val[1:] / SPY_val[:-1].values)-1
+    daily_ret_SPY = daily_ret_SPY.ix[1:]
+
     # Continue calculating stats
     avg_daily_ret = daily_ret.mean()
     std_daily_ret = daily_ret.std()
-    sharpe_ratio = np.sqrt(samples_per_year) * (daily_ret-daily_rf).mean()/daily_ret.std()
+
+    sharpe_ratio = np.sqrt(yearly_samples) * (daily_ret-daily_ret_SPY).mean()/(daily_ret-daily_ret_SPY).std()
+
     return cum_ret, avg_daily_ret, std_daily_ret, sharpe_ratio
 
 
-def optimize_allocations(prices):
+def optimize_allocations(prices, prices_SPY):
     """Find optimal allocations for a stock portfolio, optimizing for Sharpe ratio.
 
-    Keyword arguments:
-    data -- dictionary of the following form:
-        {'symbols': ['AAPL', 'FB', 'GOOG'],
-         'start_date': '01/01/2012',
-         'end_date': '03/20/2016',
-         'principle': 1000.00}
+    Args:
+        data (dict): a portfolio of the form
+            {'symbols': ['AAPL', 'FB', 'GOOG'],
+             'start_date': '01/01/2012',
+             'end_date': '03/20/2016',
+             'principle': 1000.00}
 
-    Returns
+
+    Returns:
     allocs -- dictionary of the following form:
         {'AAPL', 0.5,
          'GOOG', 0.3,
@@ -74,7 +79,10 @@ def optimize_allocations(prices):
     """
     # 1. Define 'error' function
     def sharpe(weights):
-        return get_portfolio_stats(get_portfolio_value(prices, weights))[3] * -1
+        port_val = get_portfolio_value(prices, weights)
+        SPY_val = get_portfolio_value(prices_SPY, [1])
+        sharpe = get_portfolio_stats(port_val, SPY_val)
+        return get_portfolio_stats(get_portfolio_value(prices, weights), SPY_val)[3] * -1
 
     # 2. Set bounds
     num_stocks = prices.shape[1]
@@ -95,19 +103,17 @@ def optimize_portfolio(prices, prices_SPY):
     # Get optimal allocations
     prices = prices.reindex_axis(sorted(prices.columns), axis=1)
     symbols = list(prices.columns.values)
-    allocs = optimize_allocations(prices)
+    allocs = optimize_allocations(prices, prices_SPY)
     allocs = allocs / np.sum(allocs)
 
     # Get daily portfolio value (already normalized since we use default start_val=1.0)
-    port_val = get_portfolio_value(prices, allocs).rename("Portfolio")
+    port_val = get_portfolio_value(prices, allocs)
+    SPY_val = get_portfolio_value(prices_SPY, [1])
+
+    compare_SPY = pd.concat([port_val, SPY_val], axis=1, join='inner')
 
     # Get portfolio statistics (note: std_daily_ret = volatility)
-    cum_ret, avg_daily_ret, std_daily_ret, sharpe_ratio = get_portfolio_stats(port_val)
-
-    ## To compare daily portfolio value with normalized SPY:
-    normed_SPY = prices_SPY / prices_SPY.ix[0, :]
-    normed_SPY.rename(columns={'INDEX_SPY': 'SPY'}, inplace=True)
-    compare_SPY = pd.concat([port_val, normed_SPY], axis=1, join='inner')
+    cum_ret, avg_daily_ret, std_daily_ret, sharpe_ratio = get_portfolio_stats(port_val, SPY_val)
 
     return {'optimal_allocations': {k: v for (k, v) in zip(symbols, allocs)},
             'sharpe_ratio': sharpe_ratio,
@@ -118,9 +124,9 @@ def optimize_portfolio(prices, prices_SPY):
 def main():
     """Driver function."""
     from utils import get_data
-    params = {'symbols': ['XOM', 'ABBV', 'MMM', 'GOOG', 'FB', 'SPLV'],
-              'start_date': '01/01/2015',
-              'end_date': '03/20/2015',
+    params = {'symbols': ['XOM', 'ABBV', 'MMM', 'GOOG', 'FB'],
+              'start_date': '01/01/2014',
+              'end_date': '03/20/2016',
               'principle': 1000.00}
     prices, prices_SPY = get_data(params)
     allocs = optimize_portfolio(prices, prices_SPY)

--- a/backend/optimizer/optimize.py
+++ b/backend/optimizer/optimize.py
@@ -78,18 +78,11 @@ def optimize_allocations(prices, prices_SPY):
     """Find optimal allocations for a stock portfolio, optimizing for Sharpe ratio.
 
     Args:
-        data (dict): a portfolio of the form
-            {'symbols': ['AAPL', 'FB', 'GOOG'],
-             'start_date': '01/01/2012',
-             'end_date': '03/20/2016',
-             'principle': 1000.00}
-
+        prices (dataframe): prices for stocks in our portfolio
+        prices_SPY (dataframe): prices for SPY
 
     Returns:
-    allocs -- dictionary of the following form:
-        {'AAPL', 0.5,
-         'GOOG', 0.3,
-         'FB', 0.2}
+        sharpe_ratio (float): Sharpe ratio for optimally allocated portfolio
     """
     # 1. Define 'error' function
     def sharpe(weights):
@@ -107,12 +100,19 @@ def optimize_allocations(prices, prices_SPY):
     result = spo.minimize(sharpe, num_stocks * [1. / num_stocks],
                           method='SLSQP', bounds=bnds,
                           constraints=cons, options={'disp': False})
-
     return result['x']
 
 
 def optimize_portfolio(prices, prices_SPY):
-    """Simulate and optimize portfolio allocations."""
+    """Simulate and optimize portfolio allocations.
+
+    Args:
+        prices (dataframe): prices for stocks in our portfolio
+        prices_SPY (dataframe): prices for SPY
+
+    Returns:
+        optimal_portfolio (dict): dict containing optimal portfolio stats
+    """
     # Get optimal allocations
     prices = prices.reindex_axis(sorted(prices.columns), axis=1)
     allocs = optimize_allocations(prices, prices_SPY)
@@ -126,8 +126,8 @@ def optimize_portfolio(prices, prices_SPY):
     symbols = list(prices.columns.values)
     return {'optimal_allocations': {k: v for (k, v) in zip(symbols, allocs)},
             'sharpe_ratio': get_sharpe_ratio(port_val, SPY_val),
-            'cumulative_returns': get_cumulative_returns(port_val)}
-            # 'performance': compare_SPY}
+            'cumulative_returns': get_cumulative_returns(port_val),
+            'performance': compare_SPY.to_json()}
 
 
 def main():

--- a/backend/optimizer/optimize.py
+++ b/backend/optimizer/optimize.py
@@ -117,8 +117,8 @@ def optimize_portfolio(prices, prices_SPY):
 
     return {'optimal_allocations': {k: v for (k, v) in zip(symbols, allocs)},
             'sharpe_ratio': sharpe_ratio,
-            'cumulative_returns': cum_ret,
-            'performance': compare_SPY}
+            'cumulative_returns': cum_ret}
+            # 'performance': compare_SPY}
 
 
 def main():

--- a/backend/optimizer/utils.py
+++ b/backend/optimizer/utils.py
@@ -15,17 +15,19 @@ def get_data(params):
          'principle': 1000.00}
 
     Returns:
-    stocks -- Pandas DataFrame with adjusted close of each stock in
-              data['symbols'] as columns and the date range from start_date
-              to end_date as row indices
+    prices_df -- Pandas Dataframe with adjusted close of each stock in
+                 data['symbols'] as columns and the date range from start_date
+                 to end_date as row indices
+    SPY_df -- Pandas dataframe with adjusted close of SPY
     """
     symbols = params['symbols']
     start = params['start_date']
     end = params['end_date']
 
     prices = {s: hit_quandl(s, start, end) for s in symbols}
-    stocks = pd.concat([prices[s] for s in prices], axis=1, join='inner')
-    return stocks
+    prices_df = pd.concat([prices[s] for s in prices], axis=1, join='inner')
+    SPY_df = hit_quandl('INDEX_SPY', start, end)
+    return prices_df, SPY_df
 
 
 def hit_quandl(symbol, start, end):

--- a/backend/optimizer/utils.py
+++ b/backend/optimizer/utils.py
@@ -1,24 +1,23 @@
 """Given ticker symbols and dates, get stock data from Quandl."""
 
 import Quandl
+import os
 import pandas as pd
 
 
 def get_data(params):
     """Return a pandas data frame with adjusted close data.
 
-    Keyword arguments:
-    data -- dictionary of the following form:
-        {'symbols': ['AAPL', 'FB', 'GOOG'],
-         'start_date': '01/01/2012',
-         'end_date': '03/20/2016',
-         'principle': 1000.00}
+    Args:
+        params (dict): a portfolio of form:
+            {'symbols': ['AAPL', 'FB', 'GOOG'],
+             'start_date': '01/01/2012',
+             'end_date': '03/20/2016',
+             'principle': 1000.00}
 
     Returns:
-    prices_df -- Pandas Dataframe with adjusted close of each stock in
-                 data['symbols'] as columns and the date range from start_date
-                 to end_date as row indices
-    SPY_df -- Pandas dataframe with adjusted close of SPY
+        prices_df (dataframe): adjusted close of each stock in porfolio
+        SPY_df (dataframe): adjusted close of SPY
     """
     symbols = params['symbols']
     start = params['start_date']
@@ -26,13 +25,13 @@ def get_data(params):
 
     prices = {s: hit_quandl(s, start, end) for s in symbols}
     prices_df = pd.concat([prices[s] for s in prices], axis=1, join='inner')
+
     SPY_df = hit_quandl('INDEX_SPY', start, end)
     return prices_df, SPY_df
 
 
 def hit_quandl(symbol, start, end):
     """Gets adjusted close data for a stock."""
-    import os
     quandl_token = os.environ['QUANDL_TOKEN']
     price = Quandl.get("YAHOO/{}.6".format(symbol), trim_start=start,
                        trim_end=end, authtoken=quandl_token)
@@ -44,7 +43,6 @@ def main():
               'start_date': '01/01/2012',
               'end_date': '03/20/2016',
               'principle': 1000.00}
-    print(get_data(params))
 
 if __name__ == "__main__":
     main()

--- a/src/app/optimizer/optimizer-data.service.ts
+++ b/src/app/optimizer/optimizer-data.service.ts
@@ -37,7 +37,7 @@ export class OptimizerDataService {
     if (environment.production) {
       url = 'http://stocks.coshx.com/backend';
     } else {
-      url = 'http://localhost:8000/';
+      url = 'http://localhost:8000/backend';
     }
 
     return this.http.post(url, JSON.stringify(formData))


### PR DESCRIPTION
Changes Sharpe ratio calculation to true ex ante calculation where SPY is used as the risk-free rate instead of treasury bonds. Refactors and updates the docstrings for many backend functions. Returns a dataframe of the optimal portfolio values vs. SPY.
